### PR TITLE
Reduce some redundancy in the Network class.

### DIFF
--- a/strong_graphs/generator.py
+++ b/strong_graphs/generator.py
@@ -66,7 +66,7 @@ def determine_shortest_path_distances(tree):
     queue = set([0])
     while queue:
         u = queue.pop()
-        for v, w in tree.successors(u, with_weight=True):
+        for v, w in tree.successors(u):
             distances[v] = distances[u] + w
             queue.add(v)
     return distances
@@ -122,7 +122,7 @@ def gen_remaining_arcs(
     def non_loop_tree_arc(v):
         """Finds the predecessor is isn't the loop arc if one exists. Note that here there
         is at most two predecessors so this should be quick."""
-        for u in graph.predecessors(v):
+        for u, _ in graph.predecessors(v):
             if u != (v - 1) % n:
                 return (u, v)
         return None

--- a/strong_graphs/network.py
+++ b/strong_graphs/network.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 import networkx as nx
 
 
@@ -7,22 +6,26 @@ class Network:
 
     def __init__(self, id=None):
         self.id = id
-        self._nodes = set()  # {node_id: Node}
         self._arcs = dict()
-        self._predecessors = defaultdict(set)
-        self._successors = defaultdict(set)
+        self._predecessors = {}
+        self._successors = {}
 
     def __eq__(self, other):
-        return self._nodes == other._nodes and self._arcs == other._arcs
+        return (
+            self._arcs == other._arcs and
+            self._predecessors == other._predecessors and
+            self._successors == other._successors
+        )
 
     def add_node(self, node_id):
-        assert node_id not in self._nodes, f"{node_id} already a node"
-        self._nodes.add(node_id)
+        assert node_id not in self._predecessors, f"{node_id} already a node"
+        self._predecessors[node_id] = set()
+        self._successors[node_id] = set()
         return node_id
 
     def add_arc(self, u, v, w=0):
-        assert u in self._nodes, f"{u} not a node"
-        assert v in self._nodes, f"{v} not a node"
+        assert u in self._predecessors, f"{u} not a node"
+        assert v in self._predecessors, f"{v} not a node"
         assert u != v, f"no self loops {u} = {v}"
         assert (u, v) not in self._arcs.keys()
         self._arcs[(u, v)] = w
@@ -30,32 +33,24 @@ class Network:
         self._successors[u].add((v, w))
 
     def number_of_nodes(self):
-        return len(self._nodes)
+        return len(self._predecessors)
 
     def number_of_arcs(self):
         return len(self._arcs)
 
     def nodes(self):
-        yield from self._nodes
+        yield from self._predecessors
 
     def arcs(self):
         for u, successors in self._successors.items():
             for v, w in successors:
                 yield u, v, w
 
-    def predecessors(self, node_id, with_weight=False):
-        if with_weight:
-            yield from self._predecessors[node_id]
-        else:
-            for pred_id, _ in self._predecessors[node_id]:
-                yield pred_id
+    def predecessors(self, node_id):
+        yield from self._predecessors[node_id]
 
-    def successors(self, node_id, with_weight=False):
-        if with_weight:
-            yield from self._successors[node_id]
-        else:
-            for succ_id, _ in self._successors[node_id]:
-                yield succ_id
+    def successors(self, node_id):
+        yield from self._successors[node_id]
 
 
 def to_networkx(graph):


### PR DESCRIPTION
Could get rid of the with_weight parameter?  The caller can just discard the second part of the tuple if they don't need it.

https://github.com/stevedwards/strong-graphs/blob/85f354ca4ff06d9afafabfacdaa2ee8b28d4c400/strong_graphs/network.py#L46-L51

Also there's a bit of redundant record-keeping going on in this class with the nodes, arcs, predecessors & successors structures. `_nodes` is never needed, and `_arcs` is only used to check if a node is being added again (in an assertion, so doesn't need to be efficient).

I had a quick go at simplifying this, but it changed the graph produced by `python generate.py 20`... is there something in the generator algorithm that would be depending on node/arc ordering??﻿
